### PR TITLE
Added instantaneous PSF and E Field

### DIFF
--- a/conf/sh_8x8.py
+++ b/conf/sh_8x8.py
@@ -10,51 +10,53 @@ import numpy
 simConfiguration = {
 
 "Sim":{
-    "simName"       :  "sh_8x8",
-    "logfile"       :   "sh_8x8.log",
-    "pupilSize"     :   128, 
-    "nGS"           :   1,
-    "nDM"           :   2,
-    "nSci"          :   1,
-    "nIters"        :   5000,
-    "loopTime"      :   1/400.0,
-    "reconstructor" :   "MVM", 
+    "simName"           :  "sh_8x8",
+    "logfile"           :   "sh_8x8.log",
+    "pupilSize"         :   128,
+    "nGS"               :   1,
+    "nDM"               :   2,
+    "nSci"              :   1,
+    "nIters"            :   5000,
+    "loopTime"          :   1/400.0,
+    "reconstructor"     :   "MVM",
 
-    "verbosity"     :   2,
+    "verbosity"         :   2,
 
-    "saveCMat"      :   False,
-    "saveSlopes"    :   True,
-    "saveDmCommands":   False,
-    "saveLgsPsf"    :   False,
-    "saveSciPsf"    :   True,
+    "saveCMat"          :   False,
+    "saveSlopes"        :   True,
+    "saveDmCommands"    :   False,
+    "saveLgsPsf"        :   False,
+    "saveSciPsf"        :   True,
+    "saveInstPsf"       :   False,
+    "saveInstScieField" :   False,
     },
 
 "Atmosphere":{
-    "scrnNo"        :   4,
-    "scrnHeights"   :   numpy.array([0, 5000, 10000, 15000]),
-    "scrnStrengths" :   numpy.array([0.5, 0.3, 0.1, 0.1]),
-    "windDirs"      :   numpy.array([0, 45, 90, 135]),
-    "windSpeeds"    :   numpy.array([10, 10, 15, 20]),
-    "wholeScrnSize" :   2048,
-    "r0"            :   0.16,
+    "scrnNo"            :   4,
+    "scrnHeights"       :   numpy.array([0, 5000, 10000, 15000]),
+    "scrnStrengths"     :   numpy.array([0.5, 0.3, 0.1, 0.1]),
+    "windDirs"          :   numpy.array([0, 45, 90, 135]),
+    "windSpeeds"        :   numpy.array([10, 10, 15, 20]),
+    "wholeScrnSize"     :   2048,
+    "r0"                :   0.16,
     },
 
 "Telescope":{
-   "telDiam"        :   8.,  #Metres
-   "obsDiam"        :   1.1, #Central Obscuration
-   "mask"           :   "circle",
+   "telDiam"            :   8.,  #Metres
+   "obsDiam"            :   1.1, #Central Obscuration
+   "mask"               :   "circle",
     },
 
 "WFS":{
-    "GSPosition"    :   [(0,0)],
-    "GSHeight"      :   [0],
-    "nxSubaps"      :   [8],
-    "pxlsPerSubap"  :   [10],
-    "subapFOV"      :   [2.5],
-    "fftOversamp"   :   [3],
-    "wavelength"    :   [600e-9],
-    "centMethod"    :   ["brightestPxl"],
-    "centThreshold" :   [0.1],
+    "GSPosition"        :   [(0,0)],
+    "GSHeight"          :   [0],
+    "nxSubaps"          :   [8],
+    "pxlsPerSubap"      :   [10],
+    "subapFOV"          :   [2.5],
+    "fftOversamp"       :   [3],
+    "wavelength"        :   [600e-9],
+    "centMethod"        :   ["brightestPxl"],
+    "centThreshold"     :   [0.1],
 
     },
 
@@ -63,20 +65,20 @@ simConfiguration = {
     },
 
 "DM":{
-    "type"           :   ["TT",     "Piezo"],
-    "nxActuators"    :    [2,         9],
-    "svdConditioning":   [1e-15,     0.05],
-    "closed"         :   [True,      True],
-    "gain"           :   [0.6,       0.7],
-    "iMatValue"      :   [2.,       0.2 ],
+    "type"              :   ["TT",     "Piezo"],
+    "nxActuators"       :    [2,         9],
+    "svdConditioning"   :   [1e-15,     0.05],
+    "closed"            :   [True,      True],
+    "gain"              :   [0.6,       0.7],
+    "iMatValue"         :   [2.,       0.2 ],
     },
 
 "Science":{
-    "position"      :   [(0,0)],
-    "FOV"           :   [2.0],
-    "wavelength"    :   [1.65e-6],
-    "pxls"          :   [128],
-    "fftOversamp"   :   [2],
+    "position"          :   [(0,0)],
+    "FOV"               :   [2.0],
+    "wavelength"        :   [1.65e-6],
+    "pxls"              :   [128],
+    "fftOversamp"       :   [2],
     }
 }
 

--- a/soapy/SCI.py
+++ b/soapy/SCI.py
@@ -196,17 +196,17 @@ class scienceCam(object):
         eField = numpy.exp(1j * (phs)) * self.scaledMask
 
         self.FFT.inputData[:self.FOVPxlNo, :self.FOVPxlNo] = eField
-        focalPlane = AOFFT.ftShift2d(self.FFT())
+        focalPlane_efield = AOFFT.ftShift2d(self.FFT())
+        
+        self.focalPlane_efield = aoSimLib.binImgs(
+            focalPlane_efield, self.sciConfig.fftOversamp)
 
-        focalPlane = numpy.abs(focalPlane)**2
-
-        self.focalPlane = aoSimLib.binImgs(
-            focalPlane, self.sciConfig.fftOversamp)
+        self.focalPlane = numpy.abs(self.focalPlane_efield.copy())**2
 
         # Normalise the psf
         self.focalPlane /= self.focalPlane.sum()
 
-    def frame(self, scrns, phaseCorrection=None):
+    def frame(self, scrns, phaseCorrection=None, e_field = False):
 
         self.scrns = scrns
         self.calcPupilPhase()
@@ -223,4 +223,8 @@ class scienceCam(object):
         
         self.instStrehl = self.focalPlane.max()/self.focalPlane.sum()/ self.psfMax
 
-        return self.focalPlane
+
+        if e_field == False:
+            return self.focalPlane
+        else:
+            return self.focalPlane_efield

--- a/soapy/confParse.py
+++ b/soapy/confParse.py
@@ -363,6 +363,8 @@ class SimConfig(ConfigObj):
                                 ("saveStrehl", False),
                                 ("saveWfsFrames", False),
                                 ("saveSciPsf", False),
+                                ("saveInstPsf", False),
+                                ("saveInstScieField", False),
                                 ("saveWFE", False),
                                 ("saveSciRes", False),
                                 ("wfsMP", False),

--- a/soapy/simulation.py
+++ b/soapy/simulation.py
@@ -489,8 +489,7 @@ class Sim(object):
 
         self.sciImgNo +=1
         for sci in xrange( self.config.sim.nSci ):
-            self.sciImgs[sci] +=self.sciCams[sci].frame(self.scrns,dmShape)
-            self.sciImgNo +=1
+            self.sciImgs[sci] += self.sciCams[sci].frame(self.scrns,dmShape)
             
             # Normalise long exposure psf
             #self.sciImgs[sci] /= self.sciImgs[sci].sum()
@@ -668,6 +667,22 @@ class Sim(object):
         else:
             self.lgsPsfs = None
 
+        #Init Instantaneous PSF saving
+        if self.config.sim.nSci>0 and self.config.sim.saveInstPsf==True:
+            self.sciImgsInst = {}
+
+            for sci in xrange(self.config.sim.nSci):
+                self.sciImgsInst[sci] = numpy.zeros([self.config.sim.nIters,self.config.scis[sci].pxls,self.config.scis[sci].pxls])
+            
+  
+        #Init Instantaneous electric field
+        if self.config.sim.nSci>0 and self.config.sim.saveInstScieField==True:
+            self.scieFieldInst = {}
+              
+            for sci in xrange(self.config.sim.nSci):
+                self.scieFieldInst[sci] = numpy.zeros(([self.config.sim.nIters,self.config.scis[sci].pxls,self.config.scis[sci].pxls]), dtype=complex )
+
+
     def storeData(self, i):
         """
         Stores data from each frame in an appropriate data structure.
@@ -717,6 +732,16 @@ class Sim(object):
                         self.wfss[wfs].wfsDetectorPlane,
                         header=self.config.sim.saveHeader)
 
+        #Save Instantaneous PSF
+        if self.config.sim.nSci>0 and self.config.sim.saveInstPsf==True:
+            for sci in xrange(self.config.sim.nSci):
+                self.sciImgsInst[sci][i,:,:] = self.sciCams[sci].frame(self.scrns,phaseCorrection= self.openCorrection+self.closedCorrection)
+
+        
+        #Save Instantaneous electric field
+        if self.config.sim.nSci>0 and self.config.sim.saveInstScieField==True:
+            for sci in xrange(self.config.sim.nSci):
+                self.scieFieldInst[sci][self.iters,:,:] = self.sciCams[sci].frame(self.scrns,phaseCorrection= self.openCorrection+self.closedCorrection,e_field=True)
 
     def saveData(self):
         """
@@ -769,6 +794,29 @@ class Sim(object):
                                         self.sciImgs[i],
                                         header=self.config.sim.saveHeader,
                                         clobber=True )
+
+            if self.config.sim.saveInstPsf:
+                for i in xrange(self.config.sim.nSci):
+                    fits.writeto(self.path+"/sciPsfInst_%02d.fits"%i,
+                                 self.sciImgsInst[i],
+                                 header=self.config.sim.saveHeader,
+                                 clobber=True )
+
+            if self.config.sim.saveInstScieField:
+                for i in xrange(self.config.sim.nSci):
+                    fits.writeto(self.path+"/scieFieldInst_%02d_real.fits"%i,
+                                 self.scieFieldInst[i].real,
+                                 header=self.config.sim.saveHeader,
+                                 clobber=True )
+
+            if self.config.sim.saveInstScieField:
+                for i in xrange(self.config.sim.nSci):
+                    fits.writeto(self.path+"/scieFieldInst_%02d_imag.fits"%i,
+                                 self.scieFieldInst[i].imag,
+                                 header=self.config.sim.saveHeader,
+                                 clobber=True )
+
+
 
     def makeSaveHeader(self):
         """


### PR DESCRIPTION
I’ve added an instantaneous PSF and E-Field. They’re not saved (or
calculated) unless saveInstPsf or saveInstScieField are set to true in
the config file.

I’ve made changes in confParse to allow these new parameters

I’ve edited the SCI module, specifically the calcFocalPlane function to
allow the calculation of the e-field and have switched so it bins
before it calcs the intensity (is this ok Andrew?) otherwise I get
differences in the results (e.g. if I later compare intensity
calculated from E field to intensity calculated in the program).

Updated the simulation module to deal with this.

I’ve only updated on config file for now - though I can also do the
others, or leave, as the relevant parameters will automatically be set
to false.