### PR TITLE
An option to include TT in instantaneous Strehl calculation.

### DIFF
--- a/soapy/SCI.py
+++ b/soapy/SCI.py
@@ -235,6 +235,9 @@ class scienceCam(object):
         # Here so when viewing data, that outside of the pupil isn't visible.
         # self.residual*=self.mask
 
-        self.instStrehl = self.focalPlane.max()/self.focalPlane.sum()/ self.psfMax
+        if self.sciConfig.instStrehlWithTT:
+            self.instStrehl = self.focalPlane[self.sciConfig.pxls//2,self.sciConfig.pxls//2]/self.focalPlane.sum()/self.psfMax
+        else:
+            self.instStrehl = self.focalPlane.max()/self.focalPlane.sum()/ self.psfMax
 
         return self.focalPlane

--- a/soapy/confParse.py
+++ b/soapy/confParse.py
@@ -769,6 +769,9 @@ class SciConfig(ConfigObj):
                              system processor number.             ``1``
         ``fftwFlag``         str: Flag to pass to FFTW
                              when preparing plan.                 ``FFTW_MEASURE``
+        ``instStrehlWithTT`` bool: Whether or not to include
+                             tip/tilt in instantaneous Strehl
+                             calculations.                       ``False``
         ==================== =================================   ===========
 
     """
@@ -785,7 +788,8 @@ class SciConfig(ConfigObj):
                                 ]
         self.optionalParams = [ ("fftOversamp", 2),
                                 ("fftwFlag", "FFTW_MEASURE"),
-                                ("fftwThreads", 1)
+                                ("fftwThreads", 1),
+                                ("instStrehlWithTT", False),
                                 ]
 
         self.initParams()


### PR DESCRIPTION
This is off by default, unless `instStrehlWithTT` is set to `True` in the science camera configuration.